### PR TITLE
Fix/parsing

### DIFF
--- a/coc/abc.py
+++ b/coc/abc.py
@@ -278,9 +278,15 @@ class DataContainer(metaclass=DataContainerMetaClass):
         cls.upgrade_cost = try_enum(UnitStat, [json_meta.get(level).get("UpgradeCost") for level in levels_available])
         cls.upgrade_resource = Resource(value=json_meta.get("UpgradeResource"))
         upgrade_times = [
-            TimeDelta(hours=json_meta.get(level, {}).get("UpgradeTimeH"))
+            TimeDelta(
+                hours=json_meta.get(level, {}).get("UpgradeTimeH", 0),
+                minutes=json_meta.get(level, {}).get("UpgradeTimeM", 0)
+            )
             for level in levels_available
-            if json_meta.get(level, {}).get("UpgradeTimeH") is not None
+            if (
+                json_meta.get(level, {}).get("UpgradeTimeH") is not None
+                or json_meta.get(level, {}).get("UpgradeTimeM") is not None
+            )
         ]
         cls.upgrade_time = try_enum(UnitStat, upgrade_times)
 

--- a/coc/abc.py
+++ b/coc/abc.py
@@ -206,6 +206,7 @@ class DataContainer(metaclass=DataContainerMetaClass):
         cls.range = try_enum(UnitStat, [json_meta.get(level).get("AttackRange") for level in levels_available])
         cls.dps = try_enum(UnitStat, [json_meta.get(level).get("DPS") for level in levels_available])
         cls.hitpoints = try_enum(UnitStat, [json_meta.get(level).get("Hitpoints") for level in levels_available])
+        cls.max_level = len(levels_available)
 
         # get production building
         production_building = json_meta.get("ProductionBuilding")

--- a/coc/static/apk_source.py
+++ b/coc/static/apk_source.py
@@ -1,0 +1,57 @@
+import requests
+from bs4 import BeautifulSoup
+import re
+import time
+
+APK_MIRROR_BASE = "https://www.apkmirror.com"
+COC_PAGE = f"{APK_MIRROR_BASE}/apk/supercell/clash-of-clans/"
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+}
+
+def get_direct_apk_url(version_suffix="2"):
+    """
+    Skips to the latest APK download page and returns a working intermediate download URL.
+    This link prompts the browser or urllib to download the actual APK.
+    """
+    session = requests.Session()
+    session.headers.update(HEADERS)
+
+    print("[*] Fetching main Clash of Clans page...")
+    resp = session.get(COC_PAGE)
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    release_link = soup.select_one("div.appRow a.downloadLink")
+    if not release_link:
+        raise Exception("ERROR: No release link found on APKMirror home page")
+
+    release_page_url = APK_MIRROR_BASE + release_link.get("href")
+    print(f"[+] Latest release page: {release_page_url}")
+
+    # Extract version string from the URL
+    version_match = re.search(r"clash-of-clans-([\d-]+)-release", release_page_url)
+    if not version_match:
+        raise Exception("ERROR: Could not extract version number from release URL")
+
+    version_str = version_match.group(1)
+    version_segments = version_str.split("-")
+    version_num = "-".join(version_segments[:3])
+
+    # Construct the direct variant page
+    download_page = f"{release_page_url}clash-of-clans-{version_num}-{version_suffix}-android-apk-download/"
+    print(f"[+] Variant download page: {download_page}")
+
+    variant_page = session.get(download_page)
+    variant_soup = BeautifulSoup(variant_page.text, "html.parser")
+
+    dl_button = variant_soup.select_one("a.downloadButton")
+    if not dl_button:
+        raise Exception("ERROR:Download button not found on variant page")
+
+    intermediate_url = APK_MIRROR_BASE + dl_button.get("href")
+    print(f"[+] Final download link (intermediate, triggers download): {intermediate_url}")
+    return intermediate_url
+
+if __name__ == "__main__":
+    print(get_direct_apk_url())

--- a/coc/static/update_static.py
+++ b/coc/static/update_static.py
@@ -173,14 +173,16 @@ def process_csv(data, file_path, save_name):
 
         base_level = all_levels[0]
         base_cols = list(levels_dict[base_level].keys())
+        
+        # Cover edge cases where some troops only have UpgradeTimeM and UpgradeTimeS if it is added
+        do_not_promote = {"UpgradeTimeH", "UpgradeTimeM", "UpgradeTimeS"}
 
         for col in base_cols:
             # check if col is present in other levels
-            found_elsewhere = False
-            for lvl in all_levels[1:]:
-                if col in levels_dict[lvl]:
-                    found_elsewhere = True
-                    break
+            if col in do_not_promote:
+                continue
+
+            found_elsewhere = any(col in levels_dict[lvl] for lvl in all_levels[1:])
             # if not found in other levels => move it up
             if not found_elsewhere:
                 if col not in levels_dict:


### PR DESCRIPTION
- Added .max_level attribute to uninitiated classes eg: `client.get_troop()` items 
- parsing fix for "UpgradeTimeM"
   - Edge case for Barbarian 1 -> 2 displayed 0 hours and no UpgradeTimeM data. Barbarian 1 -> 2 has a 5 minute upgrade time.
   - SIDE NOTE: Raged Barbarian in the Builder Base has a 15 second research time from levels 1 -> 2. There is of course no "UpgradeTimeS" in the .csv files so it becomes 0 when parsed and turned into a .json file. This page at [coc.guide](https://coc.guide/troop/barbarian2) shows this issue. Hardcode it if you care.
- APK Scraper as some versions do not have fingerprint.json 
   - Running this script now ensures that static asset updates will retrieve with fingerprint.json (unless APKMirror changes something).